### PR TITLE
feat: add /rsvp and /cfp pages for quick shortcuts to rsvp and cfp forms

### DIFF
--- a/content/cfp.md
+++ b/content/cfp.md
@@ -1,0 +1,8 @@
++++
+title = "Call for Papers"
+description = "Submit a talk for the next KochiFOSS meetup"
+layout = "cfp"
+url = "/cfp"
++++
+
+This page will redirect you to the latest Call for Papers form for the upcoming KochiFOSS meetup. 

--- a/content/rsvp.md
+++ b/content/rsvp.md
@@ -1,0 +1,8 @@
++++
+title = "RSVP"
+description = "RSVP for the next KochiFOSS meetup"
+layout = "rsvp"
+url = "/rsvp"
++++
+
+This page will redirect you to the latest RSVP form for the upcoming KochiFOSS meetup. 

--- a/layouts/_default/cfp.html
+++ b/layouts/_default/cfp.html
@@ -1,0 +1,24 @@
+{{ define "main" }}
+{{ $pages := where .Site.RegularPages "Section" "" }}
+{{ $sortedPages := sort $pages "Date" "desc" }}
+
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-3xl font-bold mb-4">Submit a Talk for KochiFOSS Meetup</h1>
+  
+  {{ if $sortedPages }}
+    {{ with (index $sortedPages 0) }}
+      {{ if .Params.cfpLink }}
+        <meta http-equiv="refresh" content="0; url={{ .Params.cfpLink }}">
+        <p class="mb-4">{{ .Title }}</p>
+        <p class="mb-4">Redirecting you to the Call for Papers form for the {{ .Params.eventDate }} meetup...</p>
+        <p class="mb-4">If you are not redirected automatically, <a href="{{ .Params.cfpLink }}" class="text-blue-600 hover:underline">click here</a>.</p>
+      {{ else }}
+        <p class="mb-4">{{ .Title }}</p>
+        <p class="mb-4">No Call for Papers form is currently available for the upcoming meetup.</p>
+      {{ end }}
+    {{ end }}
+  {{ else }}
+    <p class="mb-4">No upcoming meetups are currently scheduled. Please check back later.</p>
+  {{ end }}
+</div>
+{{ end }} 

--- a/layouts/_default/rsvp.html
+++ b/layouts/_default/rsvp.html
@@ -1,0 +1,24 @@
+{{ define "main" }}
+{{ $pages := where .Site.RegularPages "Section" "" }}
+
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-3xl font-bold mb-4">RSVP for KochiFOSS Meetup</h1>
+
+  {{ if not $pages }}
+    <p class="mb-4">No upcoming meetups are currently scheduled. Please check back later.</p>
+  {{ else }}
+    {{ $sortedPages := sort $pages "Date" "desc" }}
+    {{ with (index $sortedPages 0) }}
+      {{ if .Params.rsvpLink }}
+        <meta http-equiv="refresh" content="0; url={{ .Params.rsvpLink }}">
+        <p class="mb-4">{{ .Title }}</p>
+        <p class="mb-4">Redirecting you to the RSVP form for the {{ .Params.eventDate }} meetup...</p>
+        <p class="mb-4">If you are not redirected automatically, <a href="{{ .Params.rsvpLink }}" class="text-blue-600 hover:underline">click here</a>.</p>
+      {{ else }}
+        <p class="mb-4">{{ .Title }}</p>
+        <p class="mb-4">No RSVP form is currently available for the upcoming meetup.</p>
+      {{ end }}
+    {{ end }}
+  {{ end }}
+</div>
+{{ end }} 


### PR DESCRIPTION
This PR intends to add dedicated pages for Call for Papers (CFP) and RSVP functionality with automatic redirection to the latest forms for upcoming KochiFOSS meetups.

## What's changed
- Added CFP (Call for Papers) page (`/cfp`)
  - New content file `content/cfp.md` with frontmatter configuration
  - New layout template `layouts/_default/cfp.html`
  - Meta refresh redirect using `.Params.cfpLink`
  - Fallback content if redirect didn't go through
  
- Added RSVP page (`/rsvp`)
  - New content file `content/rsvp.md` with frontmatter configuration
  - New layout template `layouts/_default/rsvp.html`
  - Meta refresh redirect using `.Params.rsvpLink`
  - Fallback content if redirect didn't go through